### PR TITLE
fix: refine base64 whitespace handling

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -168,10 +168,8 @@ function decodeCardData(encodedData) {
 
 // Base64 문자열 정리 함수
 function cleanBase64String(base64Data) {
-  let cleaned = base64Data;
-
-  // 1. 공백 및 개행 문자 제거
-  cleaned = cleaned.replace(/\s/g, "");
+  let cleaned = base64Data.replace(/ /g, "+");
+  cleaned = cleaned.replace(/[\r\n\t]/g, "");
 
   // 2. URL-safe Base64 → 표준 Base64 (base64Url에서 온 경우)
   cleaned = cleaned.replace(/-/g, "+").replace(/_/g, "/");


### PR DESCRIPTION
## Summary
- handle spaces, carriage returns, newlines and tabs in Base64 strings before decoding

## Testing
- `node - <<'NODE' ... NODE`
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1be51b10c8320a971366899a4d36c